### PR TITLE
add support for authentication using Kerberos tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ with TouchstoneSession(
     cookiejar_filename='cookies.pickle') as s:
 ```
 
+#### Kerberos tickets
+To authenticate using Kerberos tickets, pass `KerberosAuth()` as the `auth_type` parameter to
+`TouchstoneSession`, as in:
+```
+with TouchstoneSession(
+    base_url='...',
+    auth_type=KerberosAuth(),
+    cookiejar_filename='cookies.pickle') as s:
+```
+
 ## Complete Examples
 
 ### Get your latest paystub from ADP:
@@ -134,6 +144,20 @@ This returns `Current Covidpass status: access_granted` if you are in fact up to
 For the various "new Atlas" OAUTH2 applications, you need to find the relevant authorization URL to put as the base URL.
 
 How did I find the proper URL for Covidpass? By looking in your browser's Developer Tools, you can locate the last GET request prior to redirect to `idp.mit.edu`, then remove the extraneous `state` parameter.
+
+### Get the registration list for a class, using Kerberos authentication:
+```
+from touchstone_auth import TouchstoneSession, KerberosAuth
+from bs4 import BeautifulSoup
+
+with TouchstoneSession(base_url='https://student.mit.edu/',
+                       auth_type=KerberosAuth(),
+                       cookiejar_filename='cookies.pickle') as s:
+    payload = {'termcode': '2023FA', 'SUBJECT01': '6.1600'}
+    headers = {'Referer': 'https://student.mit.edu/cgi-bin/sfprwlst_sel.sh'}
+    r = s.post('https://student.mit.edu/cgi-bin/sfprwlst.sh', data=payload, headers=headers)
+    print(BeautifulSoup(r.text, 'html.parser').pre.text)
+```
 
 ### Selecting two-factor method
 With version 0.3.0, you can also select between phone-call and Duo Push two factor

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The example here loads credentials from a json file called `credentials.json`:
 Then, in your Python file, you can do the following:
 ```
 import json
-from touchstone_auth import TouchstoneSession
+from touchstone_auth import TouchstoneSession, CertificateAuth
 
 with open('credentials.json') as cred_file:
     credentials = json.load(cred_file)
@@ -92,7 +92,7 @@ with TouchstoneSession(
 ### Get your latest paystub from ADP:
 ```
 import json
-from touchstone_auth import TouchstoneSession
+from touchstone_auth import TouchstoneSession, CertificateAuth
 
 with open('credentials.json') as cred_file:
     credentials = json.load(cred_file)
@@ -116,7 +116,7 @@ which returns
 ### Check your Covidpass building access status:
 ```
 import json
-from touchstone_auth import TouchstoneSession
+from touchstone_auth import TouchstoneSession, CertificateAuth
 
 with open('credentials.json') as cred_file:
     credentials = json.load(cred_file)
@@ -144,7 +144,7 @@ to use the phone-call two factor method in the above example, additionally impor
 the TwofactorType enum and pass it to the session constructor:
 ```
 import json
-from touchstone_auth import TouchstoneSession, TwofactorType
+from touchstone_auth import TouchstoneSession, CertificateAuth, TwofactorType
 
 with open('credentials.json') as cred_file:
     credentials = json.load(cred_file)

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setuptools.setup(
         'beautifulsoup4',
         'requests',
         'requests-pkcs12==1.10',
+        'requests-kerberos',
         'typing-extensions'
     ]
 )

--- a/src/touchstone_auth/__init__.py
+++ b/src/touchstone_auth/__init__.py
@@ -217,7 +217,10 @@ class TouchstoneSession:
             raise TypeError("Incorrect auth type passed!")
 
         duo_html = BeautifulSoup(r.text, features='html.parser')
-        duo_script = duo_html.find(id='duo_container').findChildren('script')[1].string
+        duo_container = duo_html.find(id='duo_container')
+        if duo_container is None:
+            raise TouchstoneError("Initial authentication with {} failed".format(type(self._auth).__name__))
+        duo_script = duo_container.findChildren('script')[1].string
 
         # Clean up json string before decoding
         duo_connect_string = re.search(


### PR DESCRIPTION
Thank you for this library!

This PR adds support for authenticating using Kerberos tickets instead of certificates.

The way of specifying to use Kerberos is a bit hacky (setting `pkcs12_filename` to `None`).  Happy to hear suggestions for what you think might be cleaner.  Unfortunately `pkcs12_filename` is a positional arg so it could be annoying to change.