### PR TITLE
allow specifying a base session object

### DIFF
--- a/src/touchstone_auth/sso.py
+++ b/src/touchstone_auth/sso.py
@@ -95,7 +95,8 @@ class TouchstoneSession:
         verbose:bool=False,
         *,
         auth_type:Optional[Union[CertificateAuth,UsernamePassAuth,KerberosAuth]]=None,
-        autosave_cookies:bool=True) -> None:
+        autosave_cookies:bool=True,
+        base_session:Optional[requests.Session]=None) -> None:
         """
         Creates a new Touchstone session.
 
@@ -114,9 +115,15 @@ class TouchstoneSession:
         auth_type: Determines the type of authentication to use. Pass an enum type.
         autosave_cookies: If cookies should be automatically re-saved back to the same cookiejar file
             when the session is closed.
+        base_session: Optional requests.Session object that should be used for any
+            requests issued while setting up the Touchstone session; useful if the
+            target URL requires some tweaks to the requests session object.
         """
 
-        self._session: requests.Session = requests.Session()
+        if base_session is None:
+            self._session: requests.Session = requests.Session()
+        else:
+            self._session: requests.Session = base_session
         self._base_url = base_url
         if auth_type is not None:
             # Check for invalid behavior


### PR DESCRIPTION
This change allows an application to supply an initial `requests.Session` object for `TouchstoneSession` to use.  The motivation is that recent versions of OpenSSL don't like the TLS configuration of https://student.mit.edu (returning an error DH_KEY_TOO_SMALL).  This PR's change allowed me to implement a workaround as follows:

```
class WeakDHAdapter(requests.adapters.HTTPAdapter):
    def init_poolmanager(self, *args, **kwargs):
        ctx = urllib3.util.ssl_.create_urllib3_context()
        ctx.load_default_certs()
        # Drop OpenSSL's security level from 2 (default) to 1,
        # which permits weak DH keys.
        ctx.set_ciphers("DEFAULT@SECLEVEL=1")
        kwargs["ssl_context"] = ctx
        return super().init_poolmanager(*args, **kwargs)

base_session = requests.Session()
base_session.mount("https://student.mit.edu", WeakDHAdapter())

with TouchstoneSession(base_url='https://student.mit.edu/ent/cgi-docs/sfprwscl.html', ...
                       base_session=base_session) as s:
    ...
```